### PR TITLE
Fixes spelling error of baseball

### DIFF
--- a/source/boston/index.haml
+++ b/source/boston/index.haml
@@ -106,7 +106,7 @@ body-class: boston city-show
         %h3 Baseball Hack Day Grand Prize Winner
         %p
           In addition, the team who takes the grand prize (best of the three winning teams of Boston, Philadelphia and Montreal) will also receive 
-          %a{:href => "http://www.rbigame.com/"}RBI Baeball 15.
+          %a{:href => "http://www.rbigame.com/"}RBI Baseball 15.
         %h3 
           Best Use of 
           %a{:href => "http://developer.sportsdatallc.com/docs/MLB_API"}Sports Data API


### PR DESCRIPTION
RBI Baeball => RBI Baseball