### PR TITLE
Fixes index dropdown overflow

### DIFF
--- a/css/application.css
+++ b/css/application.css
@@ -782,8 +782,7 @@ footer.main {
   background-size: cover;
   padding-top: 10vh;
   text-align: center;
-  width: 100%;
-  height: 100vh; }
+  width: 100%; }
   .hero h2 {
     color: #fff;
     font-size: 2.25em;

--- a/js/app.js
+++ b/js/app.js
@@ -7,4 +7,26 @@ $(document).ready(function() {
     $menu.toggleClass("show-menu");
   });
 
+  if ($('.hero').length) {
+    $(window).resize(assignIndexHeroHeight);
+    $(window).trigger('resize');
+  }
+
 });
+
+function assignIndexHeroHeight() {
+  var $body = $('body');
+  var $window = $(window);
+  var $hero = $('.hero');
+  var $cities = $hero.find('.dropdown-select a');
+  var $indexDropdownButton = $hero.find('.dropdown-button');
+  var buttonHeight = $indexDropdownButton.height();
+  var minHeight = $body.height() + (buttonHeight * ($cities.length + 1));
+  var windowHeight = $window.height();
+
+  if (windowHeight > minHeight) {
+    $hero.css('height', '100vh');
+  } else {
+    $hero.height(minHeight);
+  }
+}

--- a/js/app.js
+++ b/js/app.js
@@ -7,6 +7,8 @@ $(document).ready(function() {
     $menu.toggleClass("show-menu");
   });
 
+  // If home page, set up function for 
+  // document/hero sizing.
   if ($('.hero').length) {
     $(window).resize(assignIndexHeroHeight);
     $(window).trigger('resize');
@@ -20,6 +22,12 @@ function assignIndexHeroHeight() {
   var $hero = $('.hero');
   var $cities = $hero.find('.dropdown-select a');
   var $indexDropdownButton = $hero.find('.dropdown-button');
+
+  // If TypeKit hasn't loaded, button could be wrapping on
+  // smaller screens and therefore too large.
+  var originalWhiteSpace = $indexDropdownButton.css('white-space');
+  $indexDropdownButton.css('white-space', 'nowrap');
+
   var buttonHeight = $indexDropdownButton.height();
   var minHeight = $body.height() + (buttonHeight * ($cities.length + 1));
   var windowHeight = $window.height();
@@ -29,4 +37,7 @@ function assignIndexHeroHeight() {
   } else {
     $hero.height(minHeight);
   }
+
+  // Reset original CSS
+  $indexDropdownButton.css('white-space', originalWhiteSpace);
 }

--- a/scss/_index.scss
+++ b/scss/_index.scss
@@ -75,7 +75,6 @@
   padding-top: 10vh;
   text-align: center;
   width: 100%;
-  height: 100vh;
 
   h2 {
     color: #fff;


### PR DESCRIPTION
On smaller screens, the index page's dropdown can cause the document to extend below the viewport; since the hero is set to be 100vh tall, the background doesn't extend far enough. Here is the current site on my 13" Macbook:

![screen shot 2016-03-05 at 12 40 11 pm](https://cloud.githubusercontent.com/assets/7895688/13550846/bbdd65ae-e2ec-11e5-8a5a-cbac5a295f3a.png)

I wrote a little javascript to fix the problem. It basically estimates the minimum height the document would be the options expanded, and then sets the hero to be the smaller of either that height or the viewport height.

The second commit is a little hacky but avoids a problem on mobile-sized screens where TypeKit not being loaded yet was causing the estimations to be wrong.