### PR TITLE
Updated the Twilio API code.

### DIFF
--- a/api/index.html
+++ b/api/index.html
@@ -77,7 +77,7 @@ body-class: about-history
       <p>Twilio is a communications platform that allows you to send/receive SMS/MMS messages and phone calls with your code.</p>
       <ul>
         <li><a href="https://www.twilio.com/docs/quickstart">Check out our documentation and Quickstart guides</a></li>
-        <li><a href="https://www.twilio.com/user/billing/upgrade">Upgrade your account</a> and enter the promo code "Baseball Hack Day" for $25 of free credit</li>
+        <li><a href="https://www.twilio.com/user/billing/upgrade">Upgrade your account</a> and enter the promo code "BaseballHackDay" for $25 of free credit</li>
       </ul>
 
     </li>


### PR DESCRIPTION
Greg from Twilio said the correct promotional code is without spaces.